### PR TITLE
Lifetime Membership and Minimum Membership of 5 Months

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.0.0'
 
 gem 'rails', '~> 3.2.16'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,3 +201,6 @@ DEPENDENCIES
   sass-rails (~> 3.2.3)
   uglifier (>= 1.0.3)
   unicorn
+
+BUNDLED WITH
+   1.10.0.pre.2

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -41,7 +41,7 @@ class Member
   }
 
   scope :current, -> {
-    where("$or" => [ { "lifetime_membership" => true }, { "memberships.year" => this_year } ])
+    where("$or" => [ { "lifetime_membership" => true }, { "memberships.year" => { "$gte" =>  this_year } } ])
   }
 
   scope :pending, -> {
@@ -49,7 +49,7 @@ class Member
   }
 
   scope :expired, -> {
-    where("lifetime_membership" => false, "memberships.year" => { "$exists" => true, "$ne" => this_year })
+    where("lifetime_membership" => false, "memberships.year" => { "$exists" => true, "$not" => { "$gte" => this_year } } )
   }
 
   scope :mailing_list, -> {

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -13,6 +13,7 @@ class Member
   field :notes, type: String
   field :email_allowed, type: Boolean, default: true
   field :manually_updated, type: Boolean, default: false
+  field :lifetime_membership, type: Boolean, default: false
 
   embeds_many :memberships, cascade_callbacks: true
 
@@ -40,7 +41,7 @@ class Member
   }
 
   scope :current, -> {
-    elem_match(memberships: { year: this_year, start: { "$lte" => Time.now } })
+    where("$or" => [ { "lifetime_membership" => true }, { "memberships.year" => this_year } ])
   }
 
   scope :pending, -> {
@@ -48,7 +49,7 @@ class Member
   }
 
   scope :expired, -> {
-    where("memberships" => { "$exists" => true }, "memberships.year" => { "$ne" => this_year })
+    where("lifetime_membership" => false, "memberships.year" => { "$exists" => true, "$ne" => this_year })
   }
 
   scope :mailing_list, -> {
@@ -76,7 +77,7 @@ class Member
   end
 
   def current?
-    memberships.any?(&:current?)
+    lifetime_membership || memberships.any?(&:current?)
   end
 
   def pending?
@@ -84,7 +85,7 @@ class Member
   end
 
   def expired?
-    memberships.none?(&:current?) && memberships.any?(&:expired?)
+    !lifetime_membership && memberships.none?(&:current?) && memberships.any?(&:expired?)
   end
 
   def membership

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,7 +12,7 @@ class Membership
   end
 
   def current?
-    year == this_year
+    year >= this_year
   end
 
   def expired?
@@ -28,7 +28,7 @@ class Membership
   end
 
   def self.register
-    new year: this_year, start: Time.now
+    new year: Date.today.year, start: Time.now
   end
 
 end

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -31,6 +31,9 @@
     <div class="span6">
       <%= f.label :notes %>
       <%= f.text_area :notes %>
+      <%= f.label :lifetime_membership, class: "checkbox" do %>
+        <%= f.check_box :lifetime_membership%> Lifetime Membership
+      <% end %>
     </div>
   </div>
   <div class="actions">

--- a/app/views/members/_member.html.erb
+++ b/app/views/members/_member.html.erb
@@ -6,6 +6,7 @@
   <td><%= membership_status member %></td>
   <td><%= member.notes %></td>
   <td><%= member.created_at.strftime("%d/%m/%Y") %></td>
+  <td class="tick"><%== member.lifetime_membership? ? "&#10004;" : "&#10007;" %></td>
   <td class="tick"><%== member.email_allowed? ? "&#10004;" : "&#10007;" %></td>
   <td class="actions">
     <%= link_to member do %>

--- a/app/views/members/_table.html.erb
+++ b/app/views/members/_table.html.erb
@@ -9,6 +9,7 @@
   <col />
   <col />
   <col />
+  <col />
 
   <thead>
     <tr>
@@ -19,6 +20,7 @@
       <th>Status</th>
       <th>Notes</th>
       <th>Joined</th>
+      <th>Lifetime?</th>
       <th>Email?</th>
       <th></th>
     </tr>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -65,6 +65,10 @@
         <%= @member.notes %>
       </p>
     <% end %>
+    <table class="table table-bordered">
+      <th>Lifetime Membership:</th>
+      <td class=tick><%== @member.lifetime_membership? ? "&#10004;" : "&#10007;" %></td>
+    </table>
     <table class="table table-bordered table-striped">
       <thead>
         <tr><th>Membership Status: <%= membership_status @member %></th></tr>

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -20,22 +20,35 @@ describe Member do
 
   it 'starts off as a pending member' do
     member.should be_pending
+    member.should_not be_expired
+    member.should_not be_current
   end
 
   it 'can be completed' do
     member.complete
     member.should_not be_pending
     member.should be_current
+    member.should_not be_expired
   end
 
   it 'is a current member immediately once renewed' do
     member.renew
     member.should be_current
+    member.should_not be_expired
   end
 
   it 'becomes an expired member after the end of the calendar year' do
     member.renew
     Date.stub(today: Date.today + 1.year)
     member.should be_expired
+    member.should_not be_current
+  end
+
+  it 'should not expire if lifetime member' do
+    member.renew
+    member.lifetime_membership = true
+    Date.stub(today: Date.today + 15.year)
+    member.should be_current
+    member.should_not be_expired
   end
 end


### PR DESCRIPTION
Hi Russell,

Wharf requested that I update the membership site to include a lifetime
membership option.

They also requested I make memberships run for a minimum of 5 months. So,
members who are registered in January to May will not expire in May, as
currently happens, but in May of the following year.

Please have a look at my code/commits to see if I'm doing anything dumb. It all
seems to work locally, but I'm not familiar with rails.

The current way that Wharf have been saving lifetime members in the database is
to add a note with "LIFETIME" in it. To migrate the existing documents to work
with the new lifetime membership code the following query needs to be run on
the server mongo shell:

```javascript
db.members.update({ notes: { $regex: ".*LIFETIME.*" } }, { $set: { lifetime_membership: true } });
```

That should hopefully catch everything. Any edge cases will just have to be
dealt with by co-op members when they find them.